### PR TITLE
chore: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '18'
         cache: 'npm'
@@ -25,7 +25,7 @@ jobs:
     - name: Generate Demo Pages
       run: npx @masatomakino/gulptask-demo-page
     - name: Deploy Github pages
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
       if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Pin third-party GitHub Actions to commit SHA for supply chain security.

**Changes:**
- Pin all `uses:` action references from version tags to full commit SHA

**Unchanged:**
- Action versions (no upgrades)

## Test plan

- [ ] CI workflows pass with SHA-pinned actions